### PR TITLE
Add preparation of index graph to main script

### DIFF
--- a/HLA-LA.pl
+++ b/HLA-LA.pl
@@ -174,11 +174,10 @@ my $samtools_version = `$samtools_bin --version` ;
 die "Can't parse samtools version output" unless($samtools_version =~ /samtools ([\d\.]+)/);
 $samtools_version = $1;
 my $samtools_version_numeric = $samtools_version;
-if($samtools_version_numeric =~ /^(\d+)\.(\d+)\.(\d+)$/)
-{
-	$samtools_version_numeric = $1 . '.' . $2 . $3;
-}
-unless($samtools_version_numeric >= 1.3)
+$samtools_version_numeric =~ /^(\d+)\.(\d+)/;
+my $samtools_version_major = $1;
+my $samtools_version_minor = $2;
+unless($samtools_version_major > 1 or ($samtools_version_major == 1 and $samtools_version_minor >= 3))
 {
 	die "I need samtools >=1.3";
 }

--- a/HLA-LA.pl
+++ b/HLA-LA.pl
@@ -14,7 +14,6 @@ use Cwd qw/getcwd abs_path/;
 $| = 1;
 my $this_bin_dir = $FindBin::RealBin;
 
-my $prepareGraph;
 my $_BAM;
 my $graph;
 my $customGraphDir;
@@ -29,10 +28,10 @@ my $maxThreads = 1;
 my $moreReferencesDir;
 my $extractExonkMerCounts;
 my $longReads = 0;
+my $prepareGraph = 0;
 my $testing = 0;
 my $samtools_T;
 GetOptions (
-	'prepareGraph:s' => \$prepareGraph,
 	'BAM:s' => \$_BAM,
 	'graph:s' => \$graph,
 	'customGraphDir:s' => \$customGraphDir,
@@ -47,6 +46,7 @@ GetOptions (
 	'moreReferencesDir:s' => \$moreReferencesDir,
 	'extractExonkMerCounts:s' => \$extractExonkMerCounts,
 	'longReads:s' => \$longReads,
+	'prepareGraph:s' => \$prepareGraph,
 	'testing:s' => \$testing,
 	'samtools_T:s' => \$samtools_T,
 );
@@ -56,14 +56,14 @@ if ($prepareGraph)
 	my $full_graph_dir = $FindBin::RealBin . '/../graphs/' . $graph;
 	if($customGraphDir and (-e $customGraphDir))
 	{
-                my $dir = getcwd;
+		my $dir = getcwd;
 		print "Using custom graph directory $customGraphDir\n";
-                $full_graph_dir = $customGraphDir . '/' . $graph;
-                my $is_absolute = File::Spec->file_name_is_absolute( $full_graph_dir );
-                unless($is_absolute)
-                {
-                    $full_graph_dir = $dir . '/' . $customGraphDir . '/' . $graph;
-                }
+		$full_graph_dir = $customGraphDir . '/' . $graph;
+		my $is_absolute = File::Spec->file_name_is_absolute( $full_graph_dir );
+		unless($is_absolute)
+		{
+			$full_graph_dir = $dir . '/' . $customGraphDir . '/' . $graph;
+		}
 	}
 
 	my $MHC_PRG_2_bin = '../bin/HLA-LA';
@@ -130,7 +130,7 @@ elsif($picard_sam2fastq_bin =~ /picard-tools$/)
 }
 elsif($picard_sam2fastq_bin =~ /picard\.jar$/)
 {
-        $FASTQ_extraction_command_part1 = qq($java_bin -Xmx10g -XX:-UseGCOverheadLimit -jar $picard_sam2fastq_bin SamToFastq);
+		$FASTQ_extraction_command_part1 = qq($java_bin -Xmx10g -XX:-UseGCOverheadLimit -jar $picard_sam2fastq_bin SamToFastq);
 }
 elsif($picard_sam2fastq_bin =~ /picard$/)
 {
@@ -231,15 +231,14 @@ unless(-e $BAM)
 my $full_graph_dir = $FindBin::RealBin . '/../graphs/' . $graph;
 if($customGraphDir and (-e $customGraphDir))
 {
-            my $dir = getcwd;
-            print "Using custom graph directory $customGraphDir\n";
-            $full_graph_dir = $customGraphDir . '/' . $graph;
-            my $is_absolute = File::Spec->file_name_is_absolute( $full_graph_dir );
-            unless($is_absolute)
-            {   
-                $full_graph_dir = $dir . '/' . $customGraphDir . '/' . $graph;
-            }
-
+	my $dir = getcwd;
+	print "Using custom graph directory $customGraphDir\n";
+	$full_graph_dir = $customGraphDir . '/' . $graph;
+	my $is_absolute = File::Spec->file_name_is_absolute( $full_graph_dir );
+	unless($is_absolute)
+	{
+		$full_graph_dir = $dir . '/' . $customGraphDir . '/' . $graph;
+	}
 }
 
 my $known_references_dir = $full_graph_dir . '/knownReferences';

--- a/HLA-LA.pl
+++ b/HLA-LA.pl
@@ -130,7 +130,7 @@ elsif($picard_sam2fastq_bin =~ /picard-tools$/)
 }
 elsif($picard_sam2fastq_bin =~ /picard\.jar$/)
 {
-		$FASTQ_extraction_command_part1 = qq($java_bin -Xmx10g -XX:-UseGCOverheadLimit -jar $picard_sam2fastq_bin SamToFastq);
+	$FASTQ_extraction_command_part1 = qq($java_bin -Xmx10g -XX:-UseGCOverheadLimit -jar $picard_sam2fastq_bin SamToFastq);
 }
 elsif($picard_sam2fastq_bin =~ /picard$/)
 {

--- a/HLA-LA.pl
+++ b/HLA-LA.pl
@@ -54,10 +54,16 @@ GetOptions (
 if ($prepareGraph)
 {
 	my $full_graph_dir = $FindBin::RealBin . '/../graphs/' . $graph;
-	if ($customGraphDir and (-e $customGraphDir))
+	if($customGraphDir and (-e $customGraphDir))
 	{
+                my $dir = getcwd;
 		print "Using custom graph directory $customGraphDir\n";
-		$full_graph_dir = $customGraphDir . '/' . $graph;
+                $full_graph_dir = $customGraphDir . '/' . $graph;
+                my $is_absolute = File::Spec->file_name_is_absolute( $full_graph_dir );
+                unless($is_absolute)
+                {
+                    $full_graph_dir = $dir . '/' . $customGraphDir . '/' . $graph;
+                }
 	}
 
 	my $MHC_PRG_2_bin = '../bin/HLA-LA';
@@ -223,10 +229,17 @@ unless(-e $BAM)
 }
 
 my $full_graph_dir = $FindBin::RealBin . '/../graphs/' . $graph;
-if ($customGraphDir and (-e $customGraphDir))
+if($customGraphDir and (-e $customGraphDir))
 {
-	print "Using custom graph directory $customGraphDir\n";
-	$full_graph_dir = $customGraphDir . '/' . $graph;
+            my $dir = getcwd;
+            print "Using custom graph directory $customGraphDir\n";
+            $full_graph_dir = $customGraphDir . '/' . $graph;
+            my $is_absolute = File::Spec->file_name_is_absolute( $full_graph_dir );
+            unless($is_absolute)
+            {   
+                $full_graph_dir = $dir . '/' . $customGraphDir . '/' . $graph;
+            }
+
 }
 
 my $known_references_dir = $full_graph_dir . '/knownReferences';

--- a/HLA-LA.pl
+++ b/HLA-LA.pl
@@ -14,6 +14,7 @@ use Cwd qw/getcwd abs_path/;
 $| = 1;
 my $this_bin_dir = $FindBin::RealBin;
 
+my $prepareGraph;
 my $_BAM;
 my $graph;
 my $customGraphDir;
@@ -31,6 +32,7 @@ my $longReads = 0;
 my $testing = 0;
 my $samtools_T;
 GetOptions (
+	'prepareGraph:s' => \$prepareGraph,
 	'BAM:s' => \$_BAM,
 	'graph:s' => \$graph,
 	'customGraphDir:s' => \$customGraphDir,
@@ -48,6 +50,33 @@ GetOptions (
 	'testing:s' => \$testing,
 	'samtools_T:s' => \$samtools_T,
 );
+
+if ($prepareGraph)
+{
+	my $full_graph_dir = $FindBin::RealBin . '/../graphs/' . $graph;
+	if ($customGraphDir and (-e $customGraphDir))
+	{
+		print "Using custom graph directory $customGraphDir\n";
+		$full_graph_dir = $customGraphDir . '/' . $graph;
+	}
+
+	my $MHC_PRG_2_bin = '../bin/HLA-LA';
+
+	my $previous_dir = getcwd;
+	chdir($this_bin_dir) or die "Cannot cd into $this_bin_dir";
+
+	die "Binary $MHC_PRG_2_bin not there!" unless(-e $MHC_PRG_2_bin);
+	my $command_MHC_PRG = qq($MHC_PRG_2_bin --action prepareGraph --PRG_graph_dir $full_graph_dir);
+	
+	print "\nNow executing:\n$command_MHC_PRG\n";
+
+	if(system($command_MHC_PRG) != 0)
+	{
+		die "HLA-LA graph preparation not successful. Command was $command_MHC_PRG\n";
+	}
+	exit 0;
+}
+
 
 if ($extractExonkMerCounts)
 {

--- a/findPath.pm
+++ b/findPath.pm
@@ -11,11 +11,11 @@ sub check_samtools
 	die "Can't parse samtools version output" unless($samtools_version =~ /samtools ([\d\.]+)/);
 	$samtools_version = $1;
 	my $samtools_version_numeric = $samtools_version;
-	if($samtools_version_numeric =~ /^(\d+)\.(\d+)\.(\d+)$/)
-	{
-		$samtools_version_numeric = $1 . '.' . $2 . $3;
+	$samtools_version_numeric =~ /^(\d+)\.(\d+)/;
+	my $samtools_version_major = $1;
+	my $samtools_version_minor = $2;
 	}
-	unless($samtools_version_numeric >= 1.3)
+	unless($samtools_version_major > 1 or ($samtools_version_major == 1 and $samtools_version_minor >= 3))
 	{
 		die "I need samtools >=1.3";
 	}

--- a/findPath.pm
+++ b/findPath.pm
@@ -14,7 +14,6 @@ sub check_samtools
 	$samtools_version_numeric =~ /^(\d+)\.(\d+)/;
 	my $samtools_version_major = $1;
 	my $samtools_version_minor = $2;
-	}
 	unless($samtools_version_major > 1 or ($samtools_version_major == 1 and $samtools_version_minor >= 3))
 	{
 		die "I need samtools >=1.3";


### PR DESCRIPTION
This PR mainly adds a new option `--prepareGraph` to `HLA-LA.pl` which invokes the action `prepareGraph` inside of the HLA_LA binary, so we don't have to call the binary ourselves. This is especially handy when using a conda package, since the binary is located at `path/to/conda/opt/hla-la/bin/HLA-LA` and not in the `conda/bin` itself.

Calling HLA-LA.pl with `--prepareGraph 1` should do the job here. This works both when defining a custom graph directory as well as when using the default graph directory.

Second, I added a check for custom graph directories to handle both relative and absolute paths here.

Then, I fixed the `samtools` version check in `findPath.pm` and `HLA-LA.pl` according to the existing fix used in the bioconda recipe patch - this should work now for `samtools 1.10+`

Let me know what you think, @AlexanderDilthey, I hope this is helpful!